### PR TITLE
Keep runtime memory use of parser bounded

### DIFF
--- a/analyzer/njrat.spicy
+++ b/analyzer/njrat.spicy
@@ -17,7 +17,7 @@ function bytes2uint(input: bytes) : uint64 {
 }
 
 public type njRATMessages = unit {
-    messages: njRATMessage[];
+    : njRATMessage[];
 };
 
 public type njRATMessage = unit {


### PR DESCRIPTION
Since the number of messages over a TCP connection is not bounded, the list of messages in the top-level unit was also unbounded. This means that for e.g., long-running connections we might store a lot of data without ever accessing it (the Zeek event fires for individual messages and we never examine the full message list).

This patch makes that field anonymous store the memory use of the parser stays bounded, even for long-running connections.